### PR TITLE
Generalized type decoding

### DIFF
--- a/packages/datajoint-core-ffi-c/src/types/decode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/decode.rs
@@ -1,0 +1,324 @@
+use datajoint_core::error::{DataJointError, Error, ErrorCode};
+use datajoint_core::results::{TableColumnRef, TableRow};
+use datajoint_core::types::DecodeResult;
+use std::ffi::c_void;
+use std::os::raw::c_char;
+
+/// Native types that row values can be decoded to.
+///
+/// Should be parallel to datajoint_core::types::DecodeResult.
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum NativeDecodedType {
+    None,
+    Int8,
+    UInt8,
+    Int16,
+    UInt16,
+    Int32,
+    UInt32,
+    String,
+    Float32,
+    Float64,
+    Bytes,
+}
+
+/// Macro for generating buffer decoding code for literal types.
+macro_rules! generate_literal_buffer_decode {
+    (
+        $result:ident,
+        $buffer:ident,
+        $buffer_size:ident,
+        $output_size:ident,
+        $output_type:ident,
+        $($type_name:ident => $native_type:tt,)+
+        ||
+        _ => $default_case:expr
+    ) => (
+        match $result {
+            $(
+                DecodeResult::$type_name(value) => {
+                    // Check that buffer is large enough.
+                    if $buffer_size < std::mem::size_of::<$native_type>() {
+                        return ErrorCode::BufferNotEnough as i32;
+                    }
+
+                    // Move the data into the buffer.
+                    *($buffer as *mut $native_type) = value;
+
+                    // Set output variables if allowed.
+                    if !$output_size.is_null() {
+                        *$output_size = std::mem::size_of::<$native_type>();
+                    }
+                    if !$output_type.is_null() {
+                        *$output_type = NativeDecodedType::$type_name;
+                    }
+                    ErrorCode::Success as i32
+                }
+            )+
+            _ => {
+                $default_case
+            }
+        }
+    )
+}
+
+/// Decodes a single table row value to a caller-allocated buffer.DecodeResult
+///
+/// The caller is responsible for moving data out of the buffer and handling
+/// the deallocation of the buffer itself.
+#[no_mangle]
+pub unsafe extern "C" fn table_row_decode_to_buffer(
+    this: *const TableRow,
+    column: *const TableColumnRef,
+    buffer: *mut c_void,
+    buffer_size: usize,
+    output_size: *mut usize,
+    output_type: *mut NativeDecodedType,
+) -> i32 {
+    if this.is_null() || column.is_null() || buffer.is_null() {
+        return ErrorCode::NullNotAllowed as i32;
+    }
+    match (*this).try_decode(*column) {
+        Err(err) => err.code() as i32,
+        Ok(result) => {
+            generate_literal_buffer_decode!(result, buffer, buffer_size, output_size, output_type,
+                Int8 => i8,
+                UInt8 => u8,
+                Int16 => i16,
+                UInt16 => u16,
+                Int32 => i32,
+                UInt32 => u32,
+                Float32 => f32,
+                Float64 => f64,
+                ||
+                _ => match result {
+                    DecodeResult::String(string) => {
+                        if buffer_size == 0 {
+                            return ErrorCode::BufferNotEnough as i32;
+                        }
+
+                        // Can write at most buffer_size - 1 chars to assure the trailing null
+                        // char is also placed in the buffer.
+                        let write_size = std::cmp::min(string.len(), buffer_size - 1);
+
+                        // Copy string bytes to buffer bytes.
+                        let buffer_bytes = std::slice::from_raw_parts_mut(buffer as *mut u8, buffer_size);
+                        buffer_bytes[..write_size].copy_from_slice(string[..write_size].as_bytes());
+
+                        // Trailing null character.
+                        buffer_bytes[write_size] = 0;
+
+                        if !output_size.is_null() {
+                            // Trailing null is NOT accounted for in output size.
+                            *output_size = write_size;
+                        }
+                        if !output_type.is_null() {
+                            *output_type = NativeDecodedType::String;
+                        }
+                        ErrorCode::Success as i32
+                    }
+                    DecodeResult::Bytes(bytes) => {
+                        if buffer_size == 0 {
+                            return ErrorCode::BufferNotEnough as i32;
+                        }
+
+                        let write_size = std::cmp::min(bytes.len(), buffer_size);
+                        let buffer_bytes = std::slice::from_raw_parts_mut(buffer as *mut u8, buffer_size);
+                        buffer_bytes[..write_size].copy_from_slice(&bytes[..write_size]);
+
+                        if !output_size.is_null() {
+                            *output_size = write_size;
+                        }
+                        if !output_type.is_null() {
+                            *output_type = NativeDecodedType::Bytes;
+                        }
+                        ErrorCode::Success as i32
+                    }
+                    _ => ErrorCode::ColumnDecodeError as i32
+                }
+            )
+        }
+    }
+}
+
+/// A single decoded value that has been allocated by the core library.
+/// 
+/// This struct wraps a value allocated to be transmitted to C. It allows
+/// the value to be decoded to a native type by the caller.
+pub struct AllocatedDecodedValue {
+    pub(crate) data: *const c_void,
+    pub(crate) size: usize,
+    pub(crate) type_name: NativeDecodedType,
+}
+
+impl AllocatedDecodedValue {
+    /// Creates a new allocated decoded value.
+    /// 
+    /// Does not allocate any internal value.
+    pub fn new() -> Self {
+        AllocatedDecodedValue {
+            data: std::ptr::null(),
+            size: 0,
+            type_name: NativeDecodedType::None,
+        }
+    }
+
+    /// Resets the wrapper by deallocating the memory.
+    pub unsafe fn reset(&mut self) {
+        // The integrity of self.type_name should be preserved to assure
+        // these type casts work!
+        //
+        // This value cannot be set, by any means, by the outside world.
+        match self.type_name {
+            NativeDecodedType::None => (),
+            NativeDecodedType::Int8 => {
+                Box::from_raw(self.data as *mut i8);
+            }
+            NativeDecodedType::UInt8 => {
+                Box::from_raw(self.data as *mut u8);
+            }
+            NativeDecodedType::Int16 => {
+                Box::from_raw(self.data as *mut i16);
+            }
+            NativeDecodedType::UInt16 => {
+                Box::from_raw(self.data as *mut u16);
+            }
+            NativeDecodedType::Int32 => {
+                Box::from_raw(self.data as *mut i32);
+            }
+            NativeDecodedType::UInt32 => {
+                Box::from_raw(self.data as *mut u32);
+            }
+            NativeDecodedType::Float32 => {
+                Box::from_raw(self.data as *mut f32);
+            }
+            NativeDecodedType::Float64 => {
+                Box::from_raw(self.data as *mut f64);
+            }
+            NativeDecodedType::String => {
+                std::ffi::CString::from_raw(self.data as *mut c_char);
+            }
+            NativeDecodedType::Bytes => {
+                Box::from_raw(self.data as *mut u8);
+            }
+        }
+        self.size = 0;
+        self.type_name = NativeDecodedType::None;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn allocated_decoded_value_new() -> *mut AllocatedDecodedValue {
+    Box::into_raw(Box::new(AllocatedDecodedValue::new()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn allocated_decoded_value_data(this: *const AllocatedDecodedValue) -> *const c_void {
+    if this.is_null() {
+        std::ptr::null()
+    } else {
+        (*this).data
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn allocated_decoded_value_size(this: *const AllocatedDecodedValue) -> usize {
+    if this.is_null() {
+        return 0;
+    } else {
+        (*this).size
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn allocated_decoded_value_type(this: *const AllocatedDecodedValue) -> NativeDecodedType {
+    if this.is_null() {
+        return NativeDecodedType::None;
+    } else {
+        (*this).type_name
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn allocated_decoded_value_free(this: *mut AllocatedDecodedValue) {
+    if this.is_null() {
+        return;
+    }
+    (*this).reset();
+    Box::from_raw(this);
+}
+
+/// Macro for generating allocation decoding code for literal types.
+macro_rules! generate_literal_allocation_decode {
+    (
+        $result:ident,
+        $value:ident,
+        $($type_name:ident => $native_type:tt,)+
+        ||
+        _ => $default_case:expr
+    ) => (
+        match $result {
+            $(
+                DecodeResult::$type_name(value) => {
+                    (*$value).data = Box::into_raw(Box::new(value)) as *mut c_void;
+                    (*$value).size = std::mem::size_of::<$native_type>();
+                    (*$value).type_name = NativeDecodedType::$type_name;
+                    ErrorCode::Success as i32
+                }
+            )+
+            _ => {
+                $default_case
+            }
+        }
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn table_row_decode_to_allocation(
+    this: *const TableRow,
+    column: *const TableColumnRef,
+    value: *mut AllocatedDecodedValue,
+) -> i32 {
+    if this.is_null() || column.is_null() || value.is_null() {
+        return ErrorCode::NullNotAllowed as i32;
+    }
+
+    unsafe {
+        (*value).reset();
+        match (*this).try_decode(*column) {
+            Err(err) => err.code() as i32,
+            Ok(res) => generate_literal_allocation_decode!(res, value,
+                Int8 => i8,
+                UInt8 => u8,
+                Int16 => i16,
+                UInt16 => u16,
+                Int32 => i32,
+                UInt32 => u32,
+                Float32 => f32,
+                Float64 => f64,
+                ||
+                _ => match res {
+                    DecodeResult::String(string) => {
+                        (*value).size = string.len();
+                        (*value).type_name = NativeDecodedType::String;
+                        match std::ffi::CString::new(string) {
+                            Err(_) => ErrorCode::ColumnDecodeError as i32,
+                            Ok(cstr) => {
+                                (*value).data = cstr.into_raw() as *const c_void;
+                                ErrorCode::Success as i32
+                            }
+                        }
+                    }
+                    DecodeResult::Bytes(bytes) => {
+                        (*value).size = bytes.len();
+                        (*value).type_name = NativeDecodedType::Bytes;
+                        (*value).data = Box::into_raw(Box::new(bytes)) as *const c_void;
+                        ErrorCode::Success as i32
+                    }
+                    _ => ErrorCode::ColumnDecodeError as i32
+                }
+            ),
+        }
+    }
+}

--- a/packages/datajoint-core-ffi-c/src/types/decode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/decode.rs
@@ -23,7 +23,7 @@ pub enum NativeDecodedType {
     Bytes,
 }
 
-/// Decodes a single table row value to a caller-allocated buffer.DecodeResult
+/// Decodes a single table row value to a caller-allocated buffer.
 ///
 /// The caller is responsible for moving data out of the buffer and handling
 /// the deallocation of the buffer itself.
@@ -340,6 +340,12 @@ pub unsafe extern "C" fn allocated_decoded_value_free(this: *mut AllocatedDecode
     Box::from_raw(this);
 }
 
+/// Decodes a single table row value to a Rust-allocated buffer stored in a
+/// caller-allocated wrapper value.
+///
+/// The caller is responsible for moving data out of the buffer and handling
+/// the deallocation of the wrapper. When the wrapper is deallocated, the
+/// data inside is properly deallocated depending on the type.
 #[no_mangle]
 pub extern "C" fn table_row_decode_to_allocation(
     this: *const TableRow,

--- a/packages/datajoint-core-ffi-c/src/types/decode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/decode.rs
@@ -68,7 +68,7 @@ macro_rules! generate_literal_buffer_decode {
 /// The caller is responsible for moving data out of the buffer and handling
 /// the deallocation of the buffer itself.
 #[no_mangle]
-pub unsafe extern "C" fn table_row_decode_to_buffer(
+pub extern "C" fn table_row_decode_to_buffer(
     this: *const TableRow,
     column: *const TableColumnRef,
     buffer: *mut c_void,
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn table_row_decode_to_buffer(
     }
     match (*this).try_decode(*column) {
         Err(err) => err.code() as i32,
-        Ok(result) => {
+        Ok(result) => unsafe {
             generate_literal_buffer_decode!(result, buffer, buffer_size, output_size, output_type,
                 Int8 => i8,
                 UInt8 => u8,

--- a/packages/datajoint-core-ffi-c/src/types/mod.rs
+++ b/packages/datajoint-core-ffi-c/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod decode;

--- a/packages/datajoint-core/Cargo.toml
+++ b/packages/datajoint-core/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/datajoint/datajoint-core"
 futures = { version = "0.3.1" }
 futures-core = { version = "0.3.1" }
 tokio = { version = "1.11.0", features = ["full"] }
-sqlx = { version = "0.5", features = ["runtime-async-std-native-tls", "postgres", "mysql", "tls", "any"]}
+sqlx = { version = "0.5", features = ["runtime-async-std-native-tls", "postgres", "mysql", "tls", "any", "chrono"]}

--- a/packages/datajoint-core/src/error/codes.rs
+++ b/packages/datajoint-core/src/error/codes.rs
@@ -13,6 +13,7 @@ use std::fmt::{Display, Formatter, Result};
 pub enum ErrorCode {
     Success = 0,
 
+    // SQLx error codes.
     ConfigurationError,
     UnknownDatabaseError,
     IoError,
@@ -29,8 +30,14 @@ pub enum ErrorCode {
     WorkerCrashed,
     UnknownSqlxError,
 
+    // DataJoint error codes.
     NotConnected,
     NoMoreRows,
+
+    // C FFI error codes.
+    NullNotAllowed,
+    BufferNotEnough,
+    InvalidNativeType,
 }
 
 impl Display for ErrorCode {

--- a/packages/datajoint-core/src/lib.rs
+++ b/packages/datajoint-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod connection;
 pub mod error;
 pub mod results;
+pub mod types;

--- a/packages/datajoint-core/src/results/table_column.rs
+++ b/packages/datajoint-core/src/results/table_column.rs
@@ -1,4 +1,5 @@
-use sqlx::Column;
+use crate::types::DataJointType;
+use sqlx::{Column, TypeInfo};
 
 /// Trait for types that can be used to index columns.
 ///
@@ -10,6 +11,7 @@ impl<T> ColumnIndex for T where T: sqlx::ColumnIndex<sqlx::any::AnyRow> {}
 pub struct TableColumn {
     pub ordinal: usize,
     pub name: String,
+    pub type_name: DataJointType,
 }
 
 /// A reference to data about a table column.
@@ -37,11 +39,16 @@ impl<'r> TableColumnRef<'r> {
         self.column.name()
     }
 
+    pub fn type_name(&self) -> DataJointType {
+        DataJointType::from_sqlx_type_name(self.column.type_info().name())
+    }
+
     // Converts the column reference to an owned instance for storage.
     pub fn to_owned(&self) -> TableColumn {
         TableColumn {
             ordinal: self.ordinal(),
             name: self.name().to_string(),
+            type_name: self.type_name(),
         }
     }
 }

--- a/packages/datajoint-core/src/results/table_column.rs
+++ b/packages/datajoint-core/src/results/table_column.rs
@@ -17,6 +17,7 @@ pub struct TableColumn {
 /// A reference to data about a table column.
 ///
 /// Wraps `sqlx::any::AnyColumn`.
+#[derive(Copy, Clone)]
 pub struct TableColumnRef<'r> {
     column: &'r sqlx::any::AnyColumn,
 }

--- a/packages/datajoint-core/src/types/decode.rs
+++ b/packages/datajoint-core/src/types/decode.rs
@@ -1,0 +1,88 @@
+use crate::error::{DataJointError, Error, ErrorCode};
+use crate::results::{TableColumnRef, TableRow};
+use crate::types::DataJointType;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DecodeResult {
+    Int8(i8),
+    UInt8(u8),
+    Int16(i16),
+    UInt16(u16),
+    Int32(i32),
+    UInt32(u32),
+    String(String),
+    Float32(f32),
+    Float64(f64),
+    Bytes(Vec<u8>),
+}
+
+impl Display for DecodeResult {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        use DecodeResult::*;
+        match self {
+            Int8(int) => write!(f, "{}", int),
+            UInt8(int) => write!(f, "{}", int),
+            Int16(int) => write!(f, "{}", int),
+            UInt16(int) => write!(f, "{}", int),
+            Int32(int) => write!(f, "{}", int),
+            UInt32(int) => write!(f, "{}", int),
+            String(string) => write!(f, "{}", string),
+            Float32(float) => write!(f, "{}", float),
+            Float64(float) => write!(f, "{}", float),
+            Bytes(bytes) => match std::str::from_utf8(&bytes) {
+                Err(_) => Err(std::fmt::Error),
+                Ok(string) => write!(f, "{}", string),
+            },
+        }
+    }
+}
+
+impl TableRow {
+    /// Decodes the value at the given column depending on the type of the column.
+    ///
+    /// Panics on error.
+    pub fn decode(&self, column: TableColumnRef) -> DecodeResult {
+        self.try_decode(column).unwrap()
+    }
+
+    /// Decodes the value at the given column depending on the type of the column.
+    pub fn try_decode(&self, column: TableColumnRef) -> Result<DecodeResult, Error> {
+        use DataJointType::*;
+        let index = column.ordinal();
+        match column.type_name() {
+            Unknown => Err(DataJointError::new(
+                "unsupported column type",
+                ErrorCode::ColumnDecodeError,
+            )),
+            // Need to look at https://docs.rs/sqlx/0.5.9/sqlx/types/index.html closer
+            // for these types.
+            Date | Time | DateTime | Timestamp | Decimal | Attach | FilepathStore => {
+                Err(DataJointError::new(
+                    "supported column type, but no decoder implemented",
+                    ErrorCode::ColumnDecodeError,
+                ))
+            }
+            TinyInt => Ok(DecodeResult::Int8(self.try_get::<i32, usize>(index)? as i8)),
+            TinyIntUnsigned => Ok(DecodeResult::UInt8(self.try_get::<i32, usize>(index)? as u8)),
+            SmallInt => Ok(DecodeResult::Int16(
+                self.try_get::<i32, usize>(index)? as i16
+            )),
+            SmallIntUnsigned => Ok(DecodeResult::UInt16(
+                self.try_get::<i32, usize>(index)? as u16
+            )),
+            MediumInt | Int => Ok(DecodeResult::Int32(self.try_get::<i32, usize>(index)?)),
+            MediumIntUnsigned | IntUnsigned => Ok(DecodeResult::UInt32(
+                self.try_get::<i32, usize>(index)? as u32,
+            )),
+            Enum | CharN | VarCharN => {
+                Ok(DecodeResult::String(self.try_get::<String, usize>(index)?))
+            }
+            Float => Ok(DecodeResult::Float32(self.try_get::<f32, usize>(index)?)),
+            Double => Ok(DecodeResult::Float64(self.try_get::<f64, usize>(index)?)),
+            TinyBlob | MediumBlob | Blob | LongBlob => {
+                Ok(DecodeResult::Bytes(self.try_get::<Vec<u8>, usize>(index)?))
+            }
+        }
+    }
+}

--- a/packages/datajoint-core/src/types/decode.rs
+++ b/packages/datajoint-core/src/types/decode.rs
@@ -57,12 +57,10 @@ impl TableRow {
             )),
             // Need to look at https://docs.rs/sqlx/0.5.9/sqlx/types/index.html closer
             // for these types.
-            Date | Time | DateTime | Timestamp | Decimal | Attach | FilepathStore => {
-                Err(DataJointError::new(
-                    "supported column type, but no decoder implemented",
-                    ErrorCode::ColumnDecodeError,
-                ))
-            }
+            Decimal | Attach | FilepathStore => Err(DataJointError::new(
+                "supported column type, but no decoder implemented",
+                ErrorCode::ColumnDecodeError,
+            )),
             TinyInt => Ok(DecodeResult::Int8(self.try_get::<i32, usize>(index)? as i8)),
             TinyIntUnsigned => Ok(DecodeResult::UInt8(self.try_get::<i32, usize>(index)? as u8)),
             SmallInt => Ok(DecodeResult::Int16(
@@ -78,6 +76,24 @@ impl TableRow {
             Enum | CharN | VarCharN => {
                 Ok(DecodeResult::String(self.try_get::<String, usize>(index)?))
             }
+            Date => Ok(DecodeResult::String(
+                self.try_get::<sqlx::types::chrono::NaiveDate, usize>(index)?
+                    .to_string(),
+            )),
+            Time => Ok(DecodeResult::String(
+                self.try_get::<sqlx::types::chrono::NaiveTime, usize>(index)?
+                    .to_string(),
+            )),
+            DateTime => Ok(DecodeResult::String(
+                self.try_get::<sqlx::types::chrono::NaiveDateTime, usize>(index)?
+                    .to_string(),
+            )),
+            Timestamp => Ok(DecodeResult::String(
+                self.try_get::<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>, usize>(
+                    index,
+                )?
+                .to_string(),
+            )),
             Float => Ok(DecodeResult::Float32(self.try_get::<f32, usize>(index)?)),
             Double => Ok(DecodeResult::Float64(self.try_get::<f64, usize>(index)?)),
             TinyBlob | MediumBlob | Blob | LongBlob => {

--- a/packages/datajoint-core/src/types/mod.rs
+++ b/packages/datajoint-core/src/types/mod.rs
@@ -2,4 +2,5 @@ mod decode;
 mod sqlx;
 mod types;
 
+pub use decode::DecodeResult;
 pub use types::DataJointType;

--- a/packages/datajoint-core/src/types/mod.rs
+++ b/packages/datajoint-core/src/types/mod.rs
@@ -1,0 +1,5 @@
+mod decode;
+mod sqlx;
+mod types;
+
+pub use types::DataJointType;

--- a/packages/datajoint-core/src/types/sqlx.rs
+++ b/packages/datajoint-core/src/types/sqlx.rs
@@ -22,6 +22,8 @@ impl DataJointType {
             "DATE" => Date,
             "TIME" => Time,
             "DATETIME" => DateTime,
+            // MySQL considers timestamps to have a timezone, Postgres does not.
+            // This is a major problem.
             "TIMESTAMP" => Timestamp,
             "CHAR" => CharN,
             "VARCHAR" => VarCharN,

--- a/packages/datajoint-core/src/types/sqlx.rs
+++ b/packages/datajoint-core/src/types/sqlx.rs
@@ -27,7 +27,7 @@ impl DataJointType {
             // providing the database type stored in ConnectionSettings to
             // TableColumnRef::from_sqlx_type_name.
             //
-            // For now, Timestamp is broken in MySQL.
+            // For now, TIMESTAMP is broken in Postgres, but TIMESTAMPTZ is not.
             "TIMESTAMP" => Timestamp,
             "CHAR" => CharN,
             "VARCHAR" => VarCharN,

--- a/packages/datajoint-core/src/types/sqlx.rs
+++ b/packages/datajoint-core/src/types/sqlx.rs
@@ -39,8 +39,7 @@ impl DataJointType {
             "TEXT" => VarCharN,
             "FLOAT4" => Float,
             "FLOAT8" => Double,
-            "TIMESTAMPTZ" => DateTime,
-            "TIMETZ" => Time,
+            "TIMESTAMPTZ" => Timestamp,
 
             &_ => Unknown,
         }

--- a/packages/datajoint-core/src/types/sqlx.rs
+++ b/packages/datajoint-core/src/types/sqlx.rs
@@ -23,7 +23,11 @@ impl DataJointType {
             "TIME" => Time,
             "DATETIME" => DateTime,
             // MySQL considers timestamps to have a timezone, Postgres does not.
-            // This is a major problem.
+            // This is a major problem that currently cannot be resolved without
+            // providing the database type stored in ConnectionSettings to
+            // TableColumnRef::from_sqlx_type_name.
+            //
+            // For now, Timestamp is broken in MySQL.
             "TIMESTAMP" => Timestamp,
             "CHAR" => CharN,
             "VARCHAR" => VarCharN,

--- a/packages/datajoint-core/src/types/sqlx.rs
+++ b/packages/datajoint-core/src/types/sqlx.rs
@@ -1,0 +1,48 @@
+use crate::types::DataJointType;
+
+impl DataJointType {
+    /// Maps a SQLx type, currently only exposed as a string, to a
+    /// supported DataJoint type.
+    ///
+    /// Currently only supports MySQL and Postgres type names given
+    /// by SQLx.
+    pub fn from_sqlx_type_name(name: &str) -> DataJointType {
+        use DataJointType::*;
+        match name {
+            // MySQL type names.
+            "TINYINT" => TinyInt,
+            "TINYINT UNSIGNED" => TinyIntUnsigned,
+            "SMALLINT" => SmallInt,
+            "SMALLINT UNSIGNED" => SmallIntUnsigned,
+            "MEDIUMINT" => MediumInt,
+            "MEDIUMINT UNSIGNED" => MediumIntUnsigned,
+            "INT" => Int,
+            "INT UNSIGNED" => IntUnsigned,
+            "ENUM" => Enum,
+            "DATE" => Date,
+            "TIME" => Time,
+            "DATETIME" => DateTime,
+            "TIMESTAMP" => Timestamp,
+            "CHAR" => CharN,
+            "VARCHAR" => VarCharN,
+            "FLOAT" => Float,
+            "DOUBLE" => Double,
+            "DECIMAL" => Decimal,
+            "TINYBLOB" => TinyBlob,
+            "MEDIUMBLOB" => MediumBlob,
+            "BLOB" => Blob,
+            "LONGBLOB" => LongBlob,
+
+            // Postgres-specific type names.
+            "INT2" => SmallInt,
+            "INT4" => Int,
+            "TEXT" => VarCharN,
+            "FLOAT4" => Float,
+            "FLOAT8" => Double,
+            "TIMESTAMPTZ" => DateTime,
+            "TIMETZ" => Time,
+
+            &_ => DataJointType::Unknown,
+        }
+    }
+}

--- a/packages/datajoint-core/src/types/sqlx.rs
+++ b/packages/datajoint-core/src/types/sqlx.rs
@@ -42,7 +42,7 @@ impl DataJointType {
             "TIMESTAMPTZ" => DateTime,
             "TIMETZ" => Time,
 
-            &_ => DataJointType::Unknown,
+            &_ => Unknown,
         }
     }
 }

--- a/packages/datajoint-core/src/types/types.rs
+++ b/packages/datajoint-core/src/types/types.rs
@@ -1,0 +1,30 @@
+/// Generalized types supported by DataJoint.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum DataJointType {
+    Unknown,
+    TinyInt,
+    TinyIntUnsigned,
+    SmallInt,
+    SmallIntUnsigned,
+    MediumInt,
+    MediumIntUnsigned,
+    Int,
+    IntUnsigned,
+    Enum,
+    Date,
+    Time,
+    DateTime,
+    Timestamp,
+    CharN,
+    VarCharN,
+    Float,
+    Double,
+    Decimal,
+    TinyBlob,
+    MediumBlob,
+    Blob,
+    LongBlob,
+    Attach,
+    FilepathStore,
+}

--- a/packages/datajoint-core/src/types/types.rs
+++ b/packages/datajoint-core/src/types/types.rs
@@ -1,5 +1,5 @@
 /// Generalized types supported by DataJoint.
-#[repr(C)]
+#[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DataJointType {
     Unknown,


### PR DESCRIPTION
Support generic type decoding in the core library and C FFI, allowing a value in a table row to be decoded with a single function call.

In the Rust library, row values can be decoded with `TableRow::decode` (or `TableRow::try_decode`), which will return a `DecodeResult` that contains the decoded value. The `Display` trait is then overloaded so that this value can be used somewhat generically, but the enum variant will need to be unwrapped if the value should be used more extensively.

```rs
for row in my_conn
        .fetch_query("SELECT * FROM students;")
        .rest()
        .iter()
    {
        for col in row.columns() {
            match row.try_decode(col) {
                Err(error) => println!("{}", error.message()),
                Ok(value) => println!("{}: {}", col.name(), value),
            }
        }
    }
```

The C FFI supports two types of generic decoding:

#### Buffer decoding
```c
int table_row_decode_to_buffer(TableRow* this, TableColumnRef* column, void* buffer, size_t buffer_size, size_t* output_size, NativeDecodedType* type);
```

Decodes a value to a buffer allocated and owned by the caller. Data is moved into the buffer and should be moved out by the caller. Data inside the buffer, and the buffer itself, should then be freed by the caller. In buffer decoding, the caller is responsible for all memory management.

#### Rust-side allocation
```c
int table_row_decode_to_allocation(TableRow* this, TableColumnRef* column, AllocatedDecodedValue* output);
```

Decodes a value to a Rust-side allocation, which is a portion of memory allocated by the Rust library. Data is wrapped by an `AllocatedDecodedValue` struct, which communicates the location, size, and native type of the data so the caller can properly decode it. Because Rust allocates the value, it must be sent back to Rust for deallocation. The wrapper helps communicate this deallocation requirement.

Examples of these two decoding methods are found in comments below.